### PR TITLE
Fixed an issue causing some quests to show when they shouldn't

### DIFF
--- a/patchtable.lua
+++ b/patchtable.lua
@@ -415,7 +415,7 @@ function pfDatabase:QuestFilter(id, plevel, pclass, prace)
   if not quest then return end
 
   -- hide missing pre-quests
-  if quest and quest["pre"] then
+  if quest["pre"] then
     -- check all pre-quests for one to be completed
     local one_complete = nil
     for _, prequest in pairs(quest["pre"]) do
@@ -427,20 +427,20 @@ function pfDatabase:QuestFilter(id, plevel, pclass, prace)
     if not one_complete then return end
   end
   -- hide non-available quests for your race
-  if quest and quest["race"] and not ( bit.band(quest["race"], prace) == prace ) then return end
+  if quest["race"] and not ( bit.band(quest["race"], prace) == prace ) then return end
   -- hide non-available quests for your class
-  if quest and quest["class"] and not ( bit.band(quest["class"], pclass) == pclass ) then return end
+  if quest["class"] and not ( bit.band(quest["class"], pclass) == pclass ) then return end
   -- hide non-available quests for your profession
-  if quest and quest["skill"] then 
+  if quest["skill"] then 
     local playerSkillLevel = pfDatabase:GetPlayerSkill(quest["skill"])
     if not playerSkillLevel or quest["skillmin"] and playerSkillLevel < quest["skillmin"] then return end
   end
   -- hide lowlevel quests using WoW's gray level system
-  if quest and quest["lvl"] and quest["lvl"] <= GetGrayLevel(plevel) and pfQuest_config["showlowlevel"] == "0" then return end
+  if quest["lvl"] and quest["lvl"] <= GetGrayLevel(plevel) and pfQuest_config["showlowlevel"] == "0" then return end
   -- hide highlevel quests (or show those that are 3 levels above)
-  if quest and quest["min"] and quest["min"] > plevel + ( pfQuest_config["showhighlevel"] == "1" and 3 or 0 ) then return end
+  if quest["min"] and quest["min"] > plevel + ( pfQuest_config["showhighlevel"] == "1" and 3 or 0 ) then return end
   -- hide event quests
-  if quest and quest["event"] and pfQuest_config["showfestival"] == "0" then return end
+  if quest["event"] and pfQuest_config["showfestival"] == "0" then return end
   return true
 end
 


### PR DESCRIPTION
The function `pfDatabase:QuestFilter` from pfquest-wotlk was being hooked into by patchtable.lua here:
https://github.com/Bennylavaa/pfQuest-epoch/blob/c18ceb416d2e4042fe1a694a68a0197f16095755/patchtable.lua#L224-L225
But the original function was later overwritten entirely within the same file, causing the previously defined hook to no longer get called:
https://github.com/Bennylavaa/pfQuest-epoch/blob/c18ceb416d2e4042fe1a694a68a0197f16095755/patchtable.lua#L426-L429
I've moved the logic from the hook function down into the overwrite of the original, and did a bit of cleanup work.

This should make coin quests and quests where you don't meet the skill level requirement (such as commission quests) get filtered properly.