### PR TITLE
Allow commission quests past the grey-level filter

### DIFF
--- a/patchtable.lua
+++ b/patchtable.lua
@@ -237,8 +237,16 @@ function pfDatabase:QuestFilter(id, plevel, pclass, prace)
     local playerSkillLevel = pfDatabase:GetPlayerSkill(quest["skill"])
     if not playerSkillLevel or quest["skillmin"] and playerSkillLevel < quest["skillmin"] then return end
   end
-  -- hide lowlevel quests using WoW's gray level system
-  if quest["lvl"] and quest["lvl"] <= GetGrayLevel(plevel) and pfQuest_config["showlowlevel"] == "0" then return end
+  -- hide lowlevel quests using WoW's gray level system.
+  -- Commission quests are repeatable end-game content with a low base level,
+  -- so the gray filter would hide them even when the player actively wants
+  -- them. Let them through here; the dedicated epochHideCommissionQuests
+  -- option below still lets users opt out of commission quests entirely.
+  if quest["lvl"] and quest["lvl"] <= GetGrayLevel(plevel) and pfQuest_config["showlowlevel"] == "0" then
+    local loc = pfDB.quests.loc[id]
+    local isCommission = loc and loc.T and string.find(loc.T, "Commission for")
+    if not isCommission then return end
+  end
   -- hide highlevel quests (or show those that are 3 levels above)
   if quest["min"] and quest["min"] > plevel + ( pfQuest_config["showhighlevel"] == "1" and 3 or 0 ) then return end
   -- hide event quests

--- a/pfQuest-worldmap.lua
+++ b/pfQuest-worldmap.lua
@@ -624,10 +624,15 @@ function pfMap:UpdateNodes()
                                     local questLevel = tonumber(data.qlvl) or tonumber(data.lvl) or 0
                                     local minLevel = tonumber(data.min) or 0
 
+                                    -- Commission quests are repeatable end-game content with a low base
+                                    -- level; the gray-level filter would hide them even when the player
+                                    -- wants them. Let them through here — the epochHideCommissionQuests
+                                    -- option in patchtable still offers a hard opt-out.
+                                    local isCommission = title and string.find(title, "Commission for")
                                     if not isUtilityNPC then
                                         if pfQuest_config["showlowlevel"] == "0" then
                                             if questLevel > 0 and questLevel <= GetGrayLevel(playerLevel) then
-                                                if not (data.texture and string.find(data.texture, "complete")) then
+                                                if not (data.texture and string.find(data.texture, "complete")) and not isCommission then
                                                     skipNode = true
                                                     break
                                                 end
@@ -649,7 +654,7 @@ function pfMap:UpdateNodes()
                                     if not isUtilityNPC then
                                         if pfQuest_config["showlowlevel"] == "0" then
                                             if minLevel <= 1 and questLevel <= GetGrayLevel(playerLevel) then
-                                                if not (data.texture and string.find(data.texture, "complete")) then
+                                                if not (data.texture and string.find(data.texture, "complete")) and not isCommission then
                                                     skipNode = true
                                                     break
                                                 end
@@ -889,10 +894,15 @@ function pfMap:UpdateNodes()
                             local questLevel = tonumber(data.qlvl) or tonumber(data.lvl) or 0
                             local minLevel = tonumber(data.min) or 0
 
+                            -- Commission quests are repeatable end-game content with a low base
+                            -- level; the gray-level filter would hide them even when the player
+                            -- wants them. Let them through here — the epochHideCommissionQuests
+                            -- option in patchtable still offers a hard opt-out.
+                            local isCommission = title and string.find(title, "Commission for")
                             if not isUtilityNPC then
                                 if pfQuest_config["showlowlevel"] == "0" then
                                     if questLevel > 0 and questLevel <= GetGrayLevel(playerLevel) then
-                                        if not (data.texture and string.find(data.texture, "complete")) then
+                                        if not (data.texture and string.find(data.texture, "complete")) and not isCommission then
                                             skipNode = true
                                             break
                                         end
@@ -914,7 +924,7 @@ function pfMap:UpdateNodes()
                             if not isUtilityNPC then
                                 if pfQuest_config["showlowlevel"] == "0" then
                                     if minLevel <= 1 and questLevel <= GetGrayLevel(playerLevel) then
-                                        if not (data.texture and string.find(data.texture, "complete")) then
+                                        if not (data.texture and string.find(data.texture, "complete")) and not isCommission then
                                             skipNode = true
                                             break
                                         end


### PR DESCRIPTION
## Summary

Commission-for-* quests are repeatable end-game content pinned to a low base level (level 1-10 typically). With `pfQuest_config.showlowlevel == "0"` (the default), they drop off the map as soon as the player outlevels the base level — even though they're still current content, and the map icon is the only way the player can see where to turn them in.

This PR whitelists them from the grey-level filter only. `epochHideCommissionQuests` still works as the hard opt-out for users who'd rather not see them at all.

## Changes

- **`patchtable.lua`** `pfDatabase:QuestFilter` — bypass the `quest["lvl"] <= GetGrayLevel(plevel)` gate when the quest title matches `Commission for`.
- **`pfQuest-worldmap.lua`** — same bypass in four `skipNode = true; break` sites inside `pfMap:UpdateNodes()`:
  - continent branch / `questLevel <= GetGrayLevel` check
  - continent branch / `minLevel <= 1 and questLevel <= GetGrayLevel` suspiciously-low-min check
  - zone branch / same two checks

All four sites follow the same pattern: cache `isCommission = title and string.find(title, "Commission for")` once per iteration, and add `and not isCommission` to the existing gate.

## Test plan

- [x] Log in at level 60, open world map in a low-level zone that has commission quests — they now show.
- [x] Toggle `pfQuest_config.epochHideCommissionQuests = "1"` — commissions disappear (confirms the existing opt-out still works).
- [x] Toggle `pfQuest_config.showlowlevel = "1"` — all low-level quests show, commissions included (no regression from the old path).
- [x] Complete a commission quest — icon switches to the completion texture and still renders (the `data.texture ~ "complete"` branch was already outside the gated section).