### PR TITLE
Add Rares/Chests toggle buttons to the WorldMap

### DIFF
--- a/pfQuest-worldmap.lua
+++ b/pfQuest-worldmap.lua
@@ -1145,3 +1145,127 @@ f:SetScript(
         ExtendPfQuestConfig()
     end
 )
+
+-- ============================================================================
+-- Rares / Chests toggle buttons on the WorldMap
+--
+-- Two small toggle buttons anchored inside WorldMapPositioningGuide top-right
+-- that flip `pfDatabase:TrackMeta("rares"|"chests", ...)` on or off with a
+-- single click. Equivalent to typing /db track rares / /db track chests but
+-- visible at a glance and clickable without closing the map.
+--
+-- Implementation notes:
+--   * WORLD_MAP_UPDATE drives the visual-state refresh (safely outside the
+--     protected chain). Hooking WorldMapFrame_Update or OnShow breaks
+--     SetupFullscreenScale on 3.3.5 clients.
+--   * SetFrameStrata("DIALOG") + SetFrameLevel(100) keeps the buttons
+--     clickable in windowed map mode where the guide frame otherwise
+--     covers them.
+-- ============================================================================
+local function CreateTrackingToggleButtons()
+    local BTN_W, BTN_H = 56, 10
+    local FONT_SIZE = 7
+    local X_OFFSET = -68   -- pull left of the arrow/close buttons in the top-right corner
+    local Y_TOP    = -56   -- push down past title bar and map controls
+    local guide = WorldMapPositioningGuide
+
+    local function MakeToggleButton(name, trackKey, yOffset)
+        local btn = CreateFrame("Button", "pfQuest"..name.."ToggleBtn", guide)
+        btn:SetWidth(BTN_W)
+        btn:SetHeight(BTN_H)
+        btn:SetFrameStrata("DIALOG")
+        btn:SetFrameLevel(100)
+        btn:EnableMouse(true)
+        btn._yOffset = yOffset
+        btn:SetPoint("TOPRIGHT", guide, "TOPRIGHT", X_OFFSET, yOffset)
+
+        btn:SetBackdrop({
+            bgFile   = "Interface\\Tooltips\\UI-Tooltip-Background",
+            edgeFile = "Interface\\Tooltips\\UI-Tooltip-Border",
+            tile = true, tileSize = 8, edgeSize = 6,
+            insets = { left=1, right=1, top=1, bottom=1 },
+        })
+        btn:SetBackdropColor(0.1, 0.1, 0.1, 0.85)
+        btn:SetBackdropBorderColor(0.4, 0.4, 0.4, 1)
+
+        local label = btn:CreateFontString(nil, "OVERLAY", "GameFontNormal")
+        label:SetFont(label:GetFont(), FONT_SIZE, "OUTLINE")
+        label:SetAllPoints(btn)
+        label:SetJustifyH("CENTER")
+        label:SetJustifyV("MIDDLE")
+        btn.label = label
+
+        btn:SetHighlightTexture("Interface\\Buttons\\UI-Common-MouseHilight", "ADD")
+
+        local function UpdateText()
+            if pfQuest_track and pfQuest_track[trackKey] then
+                label:SetText(name..": |cff33ff33ON|r")
+                btn:SetBackdropColor(0.05, 0.2, 0.05, 0.9)
+            else
+                label:SetText(name..": |cffff4444OFF|r")
+                btn:SetBackdropColor(0.1, 0.1, 0.1, 0.85)
+            end
+        end
+
+        btn:SetScript("OnClick", function()
+            if pfQuest_track and pfQuest_track[trackKey] then
+                pfDatabase:TrackMeta(trackKey, false)
+            else
+                pfDatabase:TrackMeta(trackKey, {})
+            end
+            pfMap:UpdateNodes()
+            UpdateText()
+        end)
+
+        btn:SetScript("OnEnter", function()
+            GameTooltip:SetOwner(btn, "ANCHOR_BOTTOMLEFT")
+            GameTooltip:SetText("pfQuest "..name, 1, 1, 1)
+            if pfQuest_track and pfQuest_track[trackKey] then
+                GameTooltip:AddLine("Click to stop tracking "..string.lower(name)..".", 0.8, 0.8, 0.8, true)
+            else
+                GameTooltip:AddLine("Click to track "..string.lower(name).." on the map.", 0.8, 0.8, 0.8, true)
+            end
+            GameTooltip:AddLine("|cff33ffcc/db track "..trackKey.."|r", 0.6, 0.6, 0.6, true)
+            GameTooltip:Show()
+        end)
+
+        btn:SetScript("OnLeave", function()
+            GameTooltip:Hide()
+        end)
+
+        UpdateText()
+        return UpdateText
+    end
+
+    local refreshRares  = MakeToggleButton("Rares",  "rares",  Y_TOP)
+    local refreshChests = MakeToggleButton("Chests", "chests", Y_TOP - BTN_H)
+
+    -- Keep buttons in sync on every map open/refresh. Re-apply the anchor in
+    -- case the guide frame moved (windowed <-> fullscreen toggle).
+    local syncFrame = CreateFrame("Frame")
+    syncFrame:RegisterEvent("WORLD_MAP_UPDATE")
+    syncFrame:SetScript("OnEvent", function()
+        pfQuestRaresToggleBtn:ClearAllPoints()
+        pfQuestRaresToggleBtn:SetPoint("TOPRIGHT", guide, "TOPRIGHT", X_OFFSET, Y_TOP)
+        pfQuestChestsToggleBtn:ClearAllPoints()
+        pfQuestChestsToggleBtn:SetPoint("TOPRIGHT", guide, "TOPRIGHT", X_OFFSET, Y_TOP - BTN_H)
+        refreshRares()
+        refreshChests()
+    end)
+
+    -- Also refresh after pfMap:UpdateNodes() so state stays live when tracking
+    -- is toggled via the slash command instead of the buttons.
+    local origUpdateNodes = pfMap.UpdateNodes
+    pfMap.UpdateNodes = function(self)
+        origUpdateNodes(self)
+        refreshRares()
+        refreshChests()
+    end
+end
+
+-- Defer until VARIABLES_LOADED so pfQuest_track / pfDatabase are initialised.
+local pfTrackBtnLoader = CreateFrame("Frame")
+pfTrackBtnLoader:RegisterEvent("VARIABLES_LOADED")
+pfTrackBtnLoader:SetScript("OnEvent", function()
+    CreateTrackingToggleButtons()
+end)


### PR DESCRIPTION
## Summary

Two small toggle buttons anchored inside `WorldMapPositioningGuide` top-right (below the close/arrow controls). One click flips `pfDatabase:TrackMeta("rares"|"chests", ...)` on or off — equivalent to typing `/db track rares` / `/db track chests`, but visible at a glance and clickable without closing the map.

The state is reflected in the label: **green** = ON, **dark** = OFF. Tooltip on hover shows the equivalent slash command for users who still prefer chat.

## Why

Toggling rare/chest tracking from the map itself is a frequent workflow — you see a rare show up, you flick it off to unclutter, you flick it back on later. Doing it via slash command requires closing the map, typing, and reopening.

## Implementation notes

- **Event choice**: `WORLD_MAP_UPDATE` drives the refresh so the button state stays in sync regardless of whether tracking is toggled via the button or the slash command. Deliberately **avoids** hooking `WorldMapFrame_Update` or setting an `OnShow` script on it — both break `SetupFullscreenScale` on 3.3.5 clients (causes map zoom/pan glitches).
- **Strata**: `SetFrameStrata("DIALOG")` + `SetFrameLevel(100)` — without these, the buttons sit under the map content in windowed mode and aren't clickable.
- **Deferred init**: wrapped in `VARIABLES_LOADED` so `pfQuest_track` and `pfDatabase` are guaranteed loaded before the buttons read their state.
- **Hooks `pfMap.UpdateNodes`**: re-runs the button-text refresh after every node update so tracking-state changes propagate immediately.
- Self-contained: all new code lives at the bottom of `pfQuest-worldmap.lua`. Zero changes to existing functions.

## Test plan

- [x] Open the world map — two buttons appear top-right with the current tracking state.
- [x] Click Rares — rares appear/disappear on the map; label flips colour; `/db track rares` state matches.
- [x] Type `/db track chests` in chat — the Chests button updates to reflect the new state next time the map opens.
- [x] Toggle windowed vs fullscreen map — buttons remain clickable and re-anchor correctly.
- [x] `/reload` with tracking on — buttons restore the correct state after load.
- [x] Fresh install (no `pfQuest_track` saved) — buttons render as OFF and clicking turns tracking ON.