### PR TITLE
Adds an option to scale the quest arrow, 0.5 to 3 scaling

### DIFF
--- a/pfQuest-config.lua
+++ b/pfQuest-config.lua
@@ -21,6 +21,10 @@ local function RebuildConfigUI()
     return true
 end
 
+local function OnConfigUIRebuilt()
+    ResizeArrow()
+end
+
 local configFrame = CreateFrame("Frame")
 configFrame:RegisterEvent("VARIABLES_LOADED")
 configFrame:SetScript("OnEvent", function(self, event)
@@ -33,6 +37,7 @@ configFrame:SetScript("OnEvent", function(self, event)
                 if RebuildConfigUI() then
                     self:SetScript("OnUpdate", nil)
                     self:UnregisterAllEvents()
+                    OnConfigUIRebuilt()
                 elseif timer > 300 then
                     self:SetScript("OnUpdate", nil)
                     self:UnregisterAllEvents()

--- a/pfQuest-epoch.toc
+++ b/pfQuest-epoch.toc
@@ -19,3 +19,4 @@ pfQuest-announce.lua
 pfQuest-tooltip.lua
 pfQuest-config.lua
 pfquest-questlog.lua
+pfQuest-arrow.lua

--- a/pfquest-arrow.lua
+++ b/pfquest-arrow.lua
@@ -1,0 +1,45 @@
+local function ExtendPfQuestConfig()
+    for _, entry in pairs(pfQuest_defconfig) do
+        if entry.config == "arrowscale" then
+            return true
+        end
+    end
+
+    local insertPos = nil
+    for id, data in pairs(pfQuest_defconfig) do
+        if data.config and data.config == "arrow" then
+            insertPos = id
+            break
+        end
+    end
+
+    if insertPos == nil then
+        return  -- shouldn't happen but don't insert the setting at a random place either
+    end
+
+    table.insert(pfQuest_defconfig, insertPos + 1,
+    {
+        text = "Arrow Scale",
+        default = "1.0",
+        type = "text",
+        config = "arrowscale",
+    })
+
+    if not pfQuest_config["arrowscale"] then
+        pfQuest_config["arrowscale"] = "1.0"
+    end
+end
+
+local configExtenderFrame = CreateFrame("Frame")
+configExtenderFrame:RegisterEvent("VARIABLES_LOADED")
+configExtenderFrame:SetScript("OnEvent", function()
+    ExtendPfQuestConfig()
+end)
+
+function ResizeArrow()
+    local scale = tonumber(pfQuest_config["arrowscale"]) or 1
+    scale = max(0.5, min(3.0, scale))
+    scale = floor(scale * 10 + 0.5) / 10
+    pfQuest_config["arrowscale"] = tostring(scale)
+    pfQuest.route.arrow:SetScale(pfQuest_config["arrowscale"])
+end


### PR DESCRIPTION
<img width="419" height="239" alt="image" src="https://github.com/user-attachments/assets/aaf1c048-562b-4358-8e7f-a9ae0913b2d4" />

Based on the arrow scaling option from pfquest-wotlk 8.0.