### PR TITLE
Commission for Alchemist Pestlezugg min lvl fix

### DIFF
--- a/db/quests-epoch.lua
+++ b/db/quests-epoch.lua
@@ -31446,7 +31446,7 @@ pfDB["quests"]["data-epoch"] = {
       ["I"] = { 13464 },
     },
     ["skill"] = 182,
-    ["skillmin"] = 300,
+    ["skillmin"] = 250,
     ["lvl"] = 50,
     ["min"] = 5,
   },


### PR DESCRIPTION
At 259 skill I was able to accept the quest