### PR TITLE
Update "Commission for Blaise Montgomery" skill level

### DIFF
--- a/db/quests-epoch.lua
+++ b/db/quests-epoch.lua
@@ -30800,7 +30800,7 @@ pfDB["quests"]["data-epoch"] = {
       ["I"] = { 8544 },
     },
     ["skill"] = 129,
-    ["skillmin"] = 250,
+    ["skillmin"] = 200,
     ["lvl"] = 40,
     ["min"] = 5,
   },


### PR DESCRIPTION
I was able to take the quest at 230 so the requirements should be 200 or 225, changed it to 200